### PR TITLE
Add retry count to maps returned from `with-retries`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+.idea/**
+**.iml

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ necessary for the body to execute successfully will be added to the result's
 metadata. This can be retrieved with `get-retry-count`:
 
 ```clj
-(let [result (with-retries [] (inc-count))]
+(let [result (with-retries [] {})]
       (get-retry-count result))
 ;0
 ```

--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ first retry immediately:
   (cons 0 exponential-backoff-strategy))
 ```
 
+### Retry count
+If the return value of the body is a Clojure map, then the number of *retries*
+necessary for the body to execute successfully will be added to the result's
+metadata. This can be retrieved with `get-retry-count`:
+
+```clj
+(let [result (with-retries [] (inc-count))]
+      (get-retry-count result))
+;0
+```
+
 ## License
 
 Copyright © 2014 Listora


### PR DESCRIPTION
Like a few others, we would really like to be able to add a bit of logging/metrics around retry attempts.

I considered a few options for possible implementations:

* You could give the body access to the retry count. I didn't like this because it would either force the user to pass in a function or use dynamic variable capture. It also is a pretty bad fit for the use case where you want to gather information about how many retries the operation takes, since you don't yet know whether the operation will succeed or fail.

* You could supply extra code bodies which could be run on failure (to log failures) or success (to log total retries necessary). This would do pretty severe damage to the simplicity of the current API - it would start to look more like the `try...catch` that we're trying to avoid in the first place.

* You could return a "result" object that contained the result of running the body and the amount of retries necessary. This would break backwards compatibility and, well, just be ugly. People who didn't care about the retry count would have to deal with it, and two results wouldn't be equal if they took different numbers of retries.

In the end, I decided to go with @mt3593 's idea of adding the retry count to the return value's metadata. This felt like the cleanest thing to do - it can safely be ignored by anyone not interested (likely to be most users initially), and leaves the simplicity of the current interface unchanged. It does mean that it won't work for all return value types, but my guess would be that most operations needing retries will return a clojure map.

I decided to add the retry count only when the return value is a map. You can add Clojure metadata to a symbol or any collection, but doing so felt a bit... gross and unexpected somehow, so I decided against it.

I decided to zero-index the retry count - ie count *retries*, not *executions*. This was partly because zero-indexing is a pretty standard convention, but also so that the special case where no retries are necessary ends up being obviously "different" with a zero value. Looking at how the tests count retries, you might disagree with this!