### PR TITLE
Add max-wall-clock-duration strategy manipulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ pom.xml.asc
 /.nrepl-port
 /.cpcache
 
+docs/superpowers/
+
 # Beads / Dolt files (added by bd init)
 .dolt/
 *.db

--- a/README.md
+++ b/README.md
@@ -169,8 +169,9 @@ could check the exception's `ex-data` and decide to fail the operation:
 
 * `clamp-delay` - limit the delay to a given number
 * `max-delay` - truncate the sequence once the delay between two attempts exceeds the given number
-* `max-duration` - truncate the sequence once the sum of all past delays exceeds the given number
+* `max-duration` - truncate the sequence once the sum of all past delays exceeds the given number (delay budget only; does not account for execution time)
 * `max-retries` - truncate the sequence after the given number of retries
+* `max-wall-clock-duration` - truncate the sequence once wall-clock elapsed time since the first attempt exceeds the given number (includes execution time, unlike `max-duration`)
 * `randomize-strategy` - scale each delay with a new random number
 
 ### Exponential backoff example:

--- a/src/again/core.clj
+++ b/src/again/core.clj
@@ -87,6 +87,28 @@
       (cons f
             (lazy-seq (max-duration (- timeout f) r))))))
 
+(defn- current-time-ms [] (System/currentTimeMillis))
+
+(defn max-wall-clock-duration
+  "Stop retrying once wall-clock time since the first attempt exceeds
+  timeout-ms. Unlike max-duration, this includes actual execution time,
+  not just accumulated delays.
+
+  Returns an options map for use with with-retries. Because it returns a
+  map rather than a seq, it must be the outermost manipulator — other
+  manipulators (max-retries, clamp-delay, etc.) should be applied to the
+  strategy before passing it here.
+
+  The returned map can be merged with other with-retries options such as
+  ::callback and ::user-context, or ::wall-clock-timeout can be set
+  directly in the options map passed to with-retries instead of using
+  this function."
+  [timeout-ms retry-strategy]
+  {:pre [(>= timeout-ms 0)
+         (not (map? retry-strategy))]}
+  {::strategy retry-strategy
+   ::wall-clock-timeout timeout-ms})
+
 (defn- sleep
   [delay]
   (Thread/sleep (long delay)))
@@ -107,6 +129,9 @@
          delays ::strategy
          :as options}
         (build-options strategy-or-options)
+        options (cond-> options
+                  (::wall-clock-timeout options)
+                  (assoc ::start-time (current-time-ms)))
 
         callback-state (merge
                         {::attempts 1 ::slept 0}
@@ -120,12 +145,15 @@
                              callback)
                          res)
                        (catch Exception e
-                         (let [retry? (-> callback-state
-                                         (assoc
-                                          ::exception e
-                                          ::status (if delay :retry :failure))
-                                         callback
-                                         (not= ::fail))]
+                         (let [timed-out? (when-let [timeout (::wall-clock-timeout options)]
+                                            (>= (- (current-time-ms) (::start-time options))
+                                                timeout))
+                               cb-result  (-> callback-state
+                                              (assoc
+                                               ::exception e
+                                               ::status (if (and delay (not timed-out?)) :retry :failure))
+                                              callback)
+                               retry?     (and (not timed-out?) (not= cb-result ::fail))]
                            (if (and delay retry?)
                              (sleep delay)
                              (throw e)))
@@ -146,7 +174,7 @@
   for a total of five attempts, with 100ms sleeps in between attempts. Note:
   infinite strategies are supported, but maybe not encouraged…
 
-  Strategies can be built with the provided builder fns, eg `linear-strategy`,
+  Strategies can be built with the provided builder fns, eg `additive-strategy`,
   and modified with the provided manipulator fns, eg `clamp-delay`, but you can
   also create any custom seq of delays that suits your use case.
 
@@ -155,7 +183,8 @@
 
   {:again.core/callback <fn>
    :again.core/strategy <delay strategy>
-   :again.core/user-context <anything, but probably an atom>}
+   :again.core/user-context <anything, but probably an atom>
+   :again.core/wall-clock-timeout <ms>}
 
   `:again.core/callback` is a callback function that is called after each
   attempt.
@@ -164,6 +193,11 @@
 
   `:again.core/user-context` is an opaque value that is passed to the callback
   function as an argument.
+
+  `:again.core/wall-clock-timeout` stops retrying once wall-clock elapsed time
+  since the first attempt exceeds this value (ms). Unlike the delay-summing
+  `max-duration` manipulator, this accounts for actual execution time. Setting
+  this key directly is equivalent to using `max-wall-clock-duration`.
 
   The callback function is called with the following type of map as its only
   argument:

--- a/test/again/core_test.clj
+++ b/test/again/core_test.clj
@@ -303,6 +303,11 @@
     (is (thrown? AssertionError (a/clamp-delay -1 (a/constant-strategy 0)))))
   (testing "max-delay rejects negative delay"
     (is (thrown? AssertionError (a/max-delay -1 (a/constant-strategy 0)))))
+  (testing "max-wall-clock-duration rejects negative timeout"
+    (is (thrown? AssertionError (a/max-wall-clock-duration -1 (a/constant-strategy 100)))))
+  (testing "max-wall-clock-duration rejects nested max-wall-clock-duration"
+    (is (thrown? AssertionError
+          (a/max-wall-clock-duration 5000 (a/max-wall-clock-duration 3000 (a/constant-strategy 100))))))
   (let [s (a/max-retries 1 (a/constant-strategy 100))]
     (testing "randomize-strategy rejects rand-factor of 0"
       (is (thrown? AssertionError (a/randomize-strategy 0 s))))
@@ -395,4 +400,76 @@
           (is (= (first @user-context) :retry) "first call is a retry")
           (is (= (second @user-context) :fail) "second call is a fail"))))))
 
+(deftest test-max-wall-clock-duration-runtime
+  (with-redefs [a/sleep (constantly nil)]
+    (testing "deadline exceeded after first failure stops retrying"
+      (let [calls    (atom 0)
+            {:keys [f attempts]} (new-failing-fn)]
+        (with-redefs [a/current-time-ms #(case (swap! calls inc) 1 0 11000)]
+          (is (thrown? Exception
+                (with-retries (a/max-wall-clock-duration 10000 [100 100 100]) (f)))))
+        (is (= @attempts 1) "only 1 attempt before wall-clock timeout fires")))
 
+    (testing "timeout not yet reached — all retries in strategy proceed"
+      (let [{:keys [f attempts]} (new-failing-fn)]
+        (with-redefs [a/current-time-ms (constantly 0)]
+          (try
+            (with-retries (a/max-wall-clock-duration 10000 [100 100 100]) (f))
+            (catch Exception _)))
+        (is (= @attempts 4) "all 3 retries fire; 4 total attempts before strategy exhaustion")))
+
+    (testing "zero timeout stops after first failure"
+      (let [{:keys [f attempts]} (new-failing-fn)]
+        (with-redefs [a/current-time-ms (constantly 0)]
+          (is (thrown? Exception
+                (with-retries (a/max-wall-clock-duration 0 [100 100 100]) (f)))))
+        (is (= @attempts 1) "only 1 attempt with zero timeout")))
+
+    (testing "success path is unaffected"
+      (let [{:keys [f]} (new-failing-fn 1)]
+        (with-redefs [a/current-time-ms (constantly 0)]
+          (is (= 1 (with-retries (a/max-wall-clock-duration 10000 [100]) (f)))
+              "returns result when operation succeeds"))))
+
+    (testing "strategy exhausted before timeout still throws"
+      (let [{:keys [f attempts]} (new-failing-fn)]
+        (with-redefs [a/current-time-ms (constantly 0)]
+          (is (thrown? Exception
+                (with-retries (a/max-wall-clock-duration 10000 [100]) (f)))))
+        (is (= @attempts 2) "1 initial + 1 retry before strategy runs out")))
+
+    (testing "callback receives :failure status when wall-clock timeout fires"
+      (let [calls    (atom 0)
+            {:keys [f]} (new-failing-fn)
+            {:keys [args callback]} (new-callback-fn)]
+        (with-redefs [a/current-time-ms #(case (swap! calls inc) 1 0 11000)]
+          (is (thrown? Exception
+                (with-retries (merge (a/max-wall-clock-duration 10000 [100 100])
+                                     {::a/callback callback})
+                              (f)))))
+        (is (= :failure (::a/status (last @args)))
+            "last callback call has :failure status on wall-clock timeout")))))
+
+(deftest test-max-wall-clock-duration-shape
+  (let [strategy [100 200 300]
+        result   (a/max-wall-clock-duration 5000 strategy)]
+    (is (map? result) "returns a map")
+    (is (= strategy (::a/strategy result)) "strategy is preserved")
+    (is (= 5000 (::a/wall-clock-timeout result)) "timeout is stored")))
+
+(defspec spec-max-wall-clock-duration
+  200
+  (prop/for-all
+   [n       (gen/choose 1 10)
+    timeout gen/s-pos-int]
+   ;; Clock advances by (timeout+1) on every call, so after the first failure
+   ;; elapsed >= (timeout+1) > timeout. Exactly 1 attempt is made regardless
+   ;; of strategy length.
+   (let [calls   (atom 0)
+         {:keys [f attempts]} (new-failing-fn)]
+     (with-redefs [a/sleep (constantly nil)
+                   a/current-time-ms #(* (inc timeout) (swap! calls inc))]
+       (try
+         (with-retries (a/max-wall-clock-duration timeout (take n (repeat 0))) (f))
+         (catch Exception _)))
+     (= @attempts 1))))


### PR DESCRIPTION
## Summary

- Adds `max-wall-clock-duration`, a new strategy manipulator that caps retries by wall-clock elapsed time (including actual execution time), complementing the existing `max-duration` which only counts accumulated delays
- Returns an options map (`{::strategy …, ::wall-clock-timeout …}`) so it composes naturally with `with-retries`'s existing map dispatch
- Adds a private `current-time-ms` var (mirrors `sleep`) for deterministic testing via `with-redefs`

Closes #9

## Test plan

- [ ] `clojure -M:test` passes (23 tests, 80 assertions)
- [ ] Unit tests cover: deadline exceeded, timeout not reached, zero timeout, success path unaffected, strategy exhausted before timeout, callback receives `:failure` status on timeout
- [ ] 200-iteration property-based spec verifies wall-clock enforcement fires regardless of strategy length
- [ ] Precondition rejects negative timeout (consistent with other manipulators)