### PR TITLE
ag-mku: add circuit breaker support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `max-wall-clock-duration` manipulator: stops retrying once wall-clock elapsed
   time since the first attempt exceeds a given timeout. Unlike `max-duration`,
   this accounts for actual execution time, not just accumulated delays.
+- Circuit breaker support: `circuit-breaker`, the `with-circuit-breaker` macro, the
+  `BreakerPolicy` protocol with the built-in `consecutive-failures` policy,
+  `circuit-open?`, and `circuit-state`. Breakers have closed/open/half-open states
+  with a configurable failure threshold and `::reset-timeout`, emit `::on-event`
+  notifications (`:success`, `:failure`, `:short-circuit`, `:state-change`), and
+  compose with `with-retries` by nesting (breaker innermost). `BreakerPolicy` is an
+  extension seam for alternative trip policies (e.g. a rolling window).
 
 ### Added
 - Callback `::status` gains a new `:interrupted` value when retrying is stopped

--- a/README.md
+++ b/README.md
@@ -252,6 +252,45 @@ first retry immediately:
   (cons 0 exponential-backoff-strategy))
 ```
 
+### Circuit breaker
+
+A circuit breaker short-circuits calls to a dependency that has been failing
+consistently, giving it time to recover and failing fast in the meantime. Construct
+one breaker and share it across callers:
+
+```clj
+(require '[again.core :as again])
+
+(def breaker
+  (again/circuit-breaker
+    (again/consecutive-failures 5)        ; trip after 5 consecutive failures
+    {:again.core/reset-timeout 30000      ; stay open 30s before a half-open probe
+     :again.core/on-event
+     (fn [{ev :again.core/event from :again.core/from to :again.core/to}]
+       (when (= ev :state-change)
+         (println "breaker" from "->" to)))}))
+
+(again/with-circuit-breaker breaker
+  (call-some-service))
+```
+
+While the breaker is open, `with-circuit-breaker` throws instead of running the
+body; `(again/circuit-open? e)` recognises that exception, and
+`(again/circuit-state breaker)` returns `:closed`, `:open`, or `:half-open`.
+
+Use retries and the breaker together by nesting, breaker innermost, so the breaker
+counts every attempt. A retry callback can stop early once the breaker opens:
+
+```clj
+(again/with-retries
+  {:again.core/strategy (again/max-retries 10 (again/constant-strategy 100))
+   :again.core/callback (fn [{e :again.core/exception}]
+                          (when (and e (again/circuit-open? e))
+                            :again.core/fail))}
+  (again/with-circuit-breaker breaker
+    (call-some-service)))
+```
+
 ## License
 
 Copyright © 2014–2026 Listora, Lauri Pesonen

--- a/src/again/core.clj
+++ b/src/again/core.clj
@@ -223,3 +223,37 @@
   exception (ie return early)."
   [strategy-or-options & body]
   `(with-retries* ~strategy-or-options (fn [] ~@body)))
+
+(defprotocol BreakerPolicy
+  "Decides when a closed circuit breaker should trip open, from observed call
+  outcomes. Implementations are immutable values; the breaker stores the current
+  policy in its state and swaps in the next one after each recorded outcome. The
+  state machine itself (open/half-open/closed) lives in the breaker runtime, not
+  here. This is the extension seam for alternative trip policies (e.g. a rolling
+  window) — implement the three methods over your own immutable value."
+  (observe [policy outcome now]
+    "Return an updated policy incorporating a call `outcome` (`:success` or
+    `:failure`) observed at `now` (epoch ms).")
+  (tripped? [policy now]
+    "True if the breaker should open, given the outcomes observed so far.")
+  (reset [policy]
+    "Return the policy with its accumulated outcome state cleared but its
+    configuration preserved. Called when the breaker (re)closes."))
+
+(defrecord ConsecutiveFailures [threshold failures]
+  BreakerPolicy
+  (observe [this outcome _now]
+    (if (= outcome :failure)
+      (update this :failures inc)
+      (assoc this :failures 0)))
+  (tripped? [_this _now]
+    (>= failures threshold))
+  (reset [this]
+    (assoc this :failures 0)))
+
+(defn consecutive-failures
+  "Returns a `BreakerPolicy` that trips after `threshold` consecutive failures.
+  A single success resets the count."
+  [threshold]
+  {:pre [(pos? threshold)]}
+  (->ConsecutiveFailures threshold 0))

--- a/src/again/core.clj
+++ b/src/again/core.clj
@@ -257,3 +257,32 @@
   [threshold]
   {:pre [(pos? threshold)]}
   (->ConsecutiveFailures threshold 0))
+
+(def ^:private default-reset-timeout
+  "Default ms a breaker stays open before admitting a half-open probe."
+  60000)
+
+(defn circuit-breaker
+  "Returns a stateful circuit breaker driven by `policy` (a `BreakerPolicy`).
+  The breaker is shared across callers and threads; construct it once.
+
+  `options` keys (all namespaced under `again.core`):
+
+    `::reset-timeout`  ms to stay open before admitting a half-open probe
+                       (default 60000)
+    `::on-event`       fn called with an event map after each notable event
+                       (see `with-circuit-breaker`); defaults to a no-op
+    `::user-context`   opaque value included in every `::on-event` map"
+  ([policy] (circuit-breaker policy {}))
+  ([policy options]
+   {:pre [(satisfies? BreakerPolicy policy)]}
+   (cond-> {::reset-timeout (get options ::reset-timeout default-reset-timeout)
+            ::on-event (get options ::on-event (constantly nil))
+            ::state (atom {::circuit :closed ::policy policy ::opened-at nil})}
+     (contains? options ::user-context)
+     (assoc ::user-context (::user-context options)))))
+
+(defn circuit-state
+  "Returns the current state of `breaker`: `:closed`, `:open`, or `:half-open`."
+  [breaker]
+  (::circuit @(::state breaker)))

--- a/src/again/core.clj
+++ b/src/again/core.clj
@@ -258,7 +258,7 @@
   {:pre [(pos? threshold)]}
   (->ConsecutiveFailures threshold 0))
 
-(def ^:private default-reset-timeout
+(def default-reset-timeout
   "Default ms a breaker stays open before admitting a half-open probe."
   60000)
 
@@ -275,7 +275,8 @@
     `::user-context`   opaque value included in every `::on-event` map"
   ([policy] (circuit-breaker policy {}))
   ([policy options]
-   {:pre [(satisfies? BreakerPolicy policy)]}
+   {:pre [(satisfies? BreakerPolicy policy)
+          (>= (get options ::reset-timeout 0) 0)]}
    (cond-> {::reset-timeout (get options ::reset-timeout default-reset-timeout)
             ::on-event (get options ::on-event (constantly nil))
             ::state (atom {::circuit :closed ::policy policy ::opened-at nil})}

--- a/src/again/core.clj
+++ b/src/again/core.clj
@@ -286,3 +286,90 @@
   "Returns the current state of `breaker`: `:closed`, `:open`, or `:half-open`."
   [breaker]
   (::circuit @(::state breaker)))
+
+(defn- decide-allow
+  "Pure step: given the current breaker `state`, decide whether a call may
+  proceed. Returns {::permitted? bool ::next <state> ::transition [from to]|nil}.
+  (Closed-only for now; the open/half-open logic is added later.)"
+  [state _now _reset-timeout]
+  (if (= (::circuit state) :closed)
+    {::permitted? true ::next state ::transition nil}
+    {::permitted? false ::next state ::transition nil}))
+
+(defn- decide-record
+  "Pure step: given the current breaker `state` and a call `outcome`, decide the
+  next state. Returns {::next <state> ::transition [from to]|nil}."
+  [state outcome now]
+  (if (= (::circuit state) :closed)
+    (let [policy' (observe (::policy state) outcome now)]
+      (if (tripped? policy' now)
+        {::next       (assoc state ::circuit :open ::policy policy' ::opened-at now)
+         ::transition [:closed :open]}
+        {::next       (assoc state ::policy policy')
+         ::transition nil}))
+    {::next state ::transition nil}))
+
+(defn- allow!
+  "Atomically apply `decide-allow` to the breaker, retrying on contention.
+  Returns {::permitted? bool ::transition [from to]|nil}."
+  [breaker]
+  (let [a             (::state breaker)
+        reset-timeout (::reset-timeout breaker)]
+    (loop []
+      (let [s        @a
+            decision (decide-allow s (current-time-ms) reset-timeout)
+            next     (::next decision)]
+        (if (or (identical? next s) (compare-and-set! a s next))
+          (dissoc decision ::next)
+          (recur))))))
+
+(defn- record!
+  "Atomically apply `decide-record` to the breaker, retrying on contention.
+  Returns {::transition [from to]|nil}."
+  [breaker outcome]
+  (let [a (::state breaker)]
+    (loop []
+      (let [s        @a
+            decision (decide-record s outcome (current-time-ms))
+            next     (::next decision)]
+        (if (or (identical? next s) (compare-and-set! a s next))
+          (dissoc decision ::next)
+          (recur))))))
+
+(defn with-circuit-breaker*
+  "Functional core of `with-circuit-breaker`: runs `f` through `breaker`."
+  [breaker f]
+  (let [{permitted? ::permitted?} (allow! breaker)]
+    (if permitted?
+      (try
+        (let [result (f)]
+          (record! breaker :success)
+          result)
+        (catch Exception e
+          (record! breaker :failure)
+          (throw e)))
+      (throw (ex-info "again.core circuit breaker is open" {::circuit-open true})))))
+
+(defmacro with-circuit-breaker
+  "Run `body` through `breaker`. While the breaker is closed (or admitting a
+  half-open probe) the body executes and its success or failure is recorded
+  against the breaker. While the breaker is open the body is NOT executed; a
+  circuit-open exception (recognised by `circuit-open?`) is thrown instead.
+
+  Any thrown `Exception` counts as a failure: it is recorded against the breaker
+  and then rethrown.
+
+  Compose with `with-retries` by nesting, breaker innermost, so the breaker sees
+  every attempt:
+
+      (with-retries strategy
+        (with-circuit-breaker breaker
+          (do-call)))"
+  [breaker & body]
+  `(with-circuit-breaker* ~breaker (fn [] ~@body)))
+
+(defn circuit-open?
+  "True if `e` is the exception thrown when a call is short-circuited by an open
+  circuit breaker (see `with-circuit-breaker`)."
+  [e]
+  (boolean (::circuit-open (ex-data e))))

--- a/src/again/core.clj
+++ b/src/again/core.clj
@@ -330,55 +330,57 @@
     :open
     {::next state ::transition nil}))
 
-(defn- allow!
-  "Atomically apply `decide-allow` to the breaker, retrying on contention.
-  Returns {::permitted? bool ::transition [from to]|nil}."
-  [breaker]
-  (let [a             (::state breaker)
-        reset-timeout (::reset-timeout breaker)]
+(defn- cas-step!
+  "Atomically transition the breaker's state with the pure `decide` fn
+  (state -> decision map containing ::next), retrying on contention. Returns the
+  decision without ::next."
+  [breaker decide]
+  (let [a (::state breaker)]
     (loop []
       (let [s        @a
-            decision (decide-allow s (current-time-ms) reset-timeout)
+            decision (decide s)
             next     (::next decision)]
         (if (or (identical? next s) (compare-and-set! a s next))
           (dissoc decision ::next)
           (recur))))))
 
+(defn- allow!
+  "Atomically apply `decide-allow` to the breaker.
+  Returns {::permitted? bool ::transition [from to]|nil}."
+  [breaker]
+  (let [reset-timeout (::reset-timeout breaker)]
+    (cas-step! breaker #(decide-allow % (current-time-ms) reset-timeout))))
+
 (defn- record!
-  "Atomically apply `decide-record` to the breaker, retrying on contention.
+  "Atomically apply `decide-record` to the breaker.
   Returns {::transition [from to]|nil}."
   [breaker outcome]
-  (let [a (::state breaker)]
-    (loop []
-      (let [s        @a
-            decision (decide-record s outcome (current-time-ms))
-            next     (::next decision)]
-        (if (or (identical? next s) (compare-and-set! a s next))
-          (dissoc decision ::next)
-          (recur))))))
+  (cas-step! breaker #(decide-record % outcome (current-time-ms))))
 
 (defn- emit!
   "Call the breaker's `::on-event` with `base`, adding `::user-context` if the
   breaker was configured with one."
   [breaker base]
   ((::on-event breaker)
-   (cond-> base
-     (contains? breaker ::user-context)
-     (assoc ::user-context (::user-context breaker)))))
+   (merge base (select-keys breaker [::user-context]))))
+
+(defn- emit-transition!
+  "Emit a `:state-change` event for `transition` ([from to]) if it is non-nil."
+  [breaker transition]
+  (when transition
+    (emit! breaker {::event :state-change ::from (first transition) ::to (second transition)})))
 
 (defn with-circuit-breaker*
   "Functional core of `with-circuit-breaker`: runs `f` through `breaker`."
   [breaker f]
   (let [{permitted? ::permitted? transition ::transition} (allow! breaker)]
-    (when transition
-      (emit! breaker {::event :state-change ::from (first transition) ::to (second transition)}))
+    (emit-transition! breaker transition)
     (if permitted?
       (try
         (let [result           (f)
               {t ::transition} (record! breaker :success)]
           (emit! breaker {::event :success})
-          (when t
-            (emit! breaker {::event :state-change ::from (first t) ::to (second t)}))
+          (emit-transition! breaker t)
           result)
         (catch InterruptedException e
           (.interrupt (Thread/currentThread))
@@ -386,8 +388,7 @@
         (catch Exception e
           (let [{t ::transition} (record! breaker :failure)]
             (emit! breaker {::event :failure ::exception e})
-            (when t
-              (emit! breaker {::event :state-change ::from (first t) ::to (second t)})))
+            (emit-transition! breaker t))
           (throw e)))
       (do
         (emit! breaker {::event :short-circuit})

--- a/src/again/core.clj
+++ b/src/again/core.clj
@@ -357,22 +357,41 @@
           (dissoc decision ::next)
           (recur))))))
 
+(defn- emit!
+  "Call the breaker's `::on-event` with `base`, adding `::user-context` if the
+  breaker was configured with one."
+  [breaker base]
+  ((::on-event breaker)
+   (cond-> base
+     (contains? breaker ::user-context)
+     (assoc ::user-context (::user-context breaker)))))
+
 (defn with-circuit-breaker*
   "Functional core of `with-circuit-breaker`: runs `f` through `breaker`."
   [breaker f]
-  (let [{permitted? ::permitted?} (allow! breaker)]
+  (let [{permitted? ::permitted? transition ::transition} (allow! breaker)]
+    (when transition
+      (emit! breaker {::event :state-change ::from (first transition) ::to (second transition)}))
     (if permitted?
       (try
-        (let [result (f)]
-          (record! breaker :success)
+        (let [result           (f)
+              {t ::transition} (record! breaker :success)]
+          (emit! breaker {::event :success})
+          (when t
+            (emit! breaker {::event :state-change ::from (first t) ::to (second t)}))
           result)
         (catch InterruptedException e
           (.interrupt (Thread/currentThread))
           (throw e))
         (catch Exception e
-          (record! breaker :failure)
+          (let [{t ::transition} (record! breaker :failure)]
+            (emit! breaker {::event :failure ::exception e})
+            (when t
+              (emit! breaker {::event :state-change ::from (first t) ::to (second t)})))
           (throw e)))
-      (throw (ex-info "again.core circuit breaker is open" {::circuit-open true})))))
+      (do
+        (emit! breaker {::event :short-circuit})
+        (throw (ex-info "again.core circuit breaker is open" {::circuit-open true}))))))
 
 (defmacro with-circuit-breaker
   "Run `body` through `breaker`. While the breaker is closed (or admitting a
@@ -384,6 +403,13 @@
   and then rethrown — except `InterruptedException`, which is rethrown with the
   interrupt flag restored and is NOT recorded (a caller interrupt is not a
   dependency-health signal).
+
+  The breaker's `::on-event` callback (see `circuit-breaker`) is invoked with a
+  map after each notable event: `{::event <type> ::user-context <ctx>}`, where
+  `<type>` is `:success`, `:failure`, `:short-circuit`, or `:state-change`. A
+  `:state-change` event also carries `::from` and `::to` states; a `:failure`
+  event also carries the `::exception`; `::user-context` is present only if one
+  was configured.
 
   Compose with `with-retries` by nesting, breaker innermost, so the breaker sees
   every attempt:

--- a/src/again/core.clj
+++ b/src/again/core.clj
@@ -366,6 +366,9 @@
         (let [result (f)]
           (record! breaker :success)
           result)
+        (catch InterruptedException e
+          (.interrupt (Thread/currentThread))
+          (throw e))
         (catch Exception e
           (record! breaker :failure)
           (throw e)))
@@ -378,7 +381,9 @@
   circuit-open exception (recognised by `circuit-open?`) is thrown instead.
 
   Any thrown `Exception` counts as a failure: it is recorded against the breaker
-  and then rethrown.
+  and then rethrown — except `InterruptedException`, which is rethrown with the
+  interrupt flag restored and is NOT recorded (a caller interrupt is not a
+  dependency-health signal).
 
   Compose with `with-retries` by nesting, breaker innermost, so the breaker sees
   every attempt:

--- a/src/again/core.clj
+++ b/src/again/core.clj
@@ -290,23 +290,44 @@
 (defn- decide-allow
   "Pure step: given the current breaker `state`, decide whether a call may
   proceed. Returns {::permitted? bool ::next <state> ::transition [from to]|nil}.
-  (Closed-only for now; the open/half-open logic is added later.)"
-  [state _now _reset-timeout]
-  (if (= (::circuit state) :closed)
-    {::permitted? true ::next state ::transition nil}
-    {::permitted? false ::next state ::transition nil}))
+  When the breaker is open and the reset timeout has elapsed, exactly one caller
+  is admitted as a half-open probe; others are denied while it is in flight."
+  [state now reset-timeout]
+  (case (::circuit state)
+    :closed    {::permitted? true  ::next state ::transition nil}
+    :half-open {::permitted? false ::next state ::transition nil}
+    :open      (if (>= (- now (::opened-at state)) reset-timeout)
+                 {::permitted? true
+                  ::next       (assoc state ::circuit :half-open)
+                  ::transition [:open :half-open]}
+                 {::permitted? false ::next state ::transition nil})))
 
 (defn- decide-record
   "Pure step: given the current breaker `state` and a call `outcome`, decide the
-  next state. Returns {::next <state> ::transition [from to]|nil}."
+  next state. Returns {::next <state> ::transition [from to]|nil}. Half-open
+  transitions are decided purely by the probe outcome; the policy is consulted
+  only while closed and reset on close."
   [state outcome now]
-  (if (= (::circuit state) :closed)
+  (case (::circuit state)
+    :closed
     (let [policy' (observe (::policy state) outcome now)]
       (if (tripped? policy' now)
         {::next       (assoc state ::circuit :open ::policy policy' ::opened-at now)
          ::transition [:closed :open]}
         {::next       (assoc state ::policy policy')
          ::transition nil}))
+
+    :half-open
+    (if (= outcome :success)
+      {::next       (assoc state ::circuit :closed ::policy (reset (::policy state)) ::opened-at nil)
+       ::transition [:half-open :closed]}
+      ;; A failed probe re-opens; ::policy is deliberately left untouched (the
+      ;; tripped state carried from the original open is preserved) and is only
+      ;; reset on a successful re-close above.
+      {::next       (assoc state ::circuit :open ::opened-at now)
+       ::transition [:half-open :open]})
+
+    :open
     {::next state ::transition nil}))
 
 (defn- allow!

--- a/test/again/core_test.clj
+++ b/test/again/core_test.clj
@@ -619,3 +619,53 @@
                  (catch Exception ex ex))]
       (is (a/circuit-open? e) "an open breaker throws a circuit-open exception")
       (is (= 0 @calls) "the wrapped body is not executed while open"))))
+
+(deftest test-circuit-breaker-half-open-probe-closes
+  (let [clock (atom 0)]
+    (with-redefs [a/current-time-ms (fn [] @clock)]
+      (let [cb   (a/circuit-breaker (a/consecutive-failures 1) {::a/reset-timeout 1000})
+            boom (Exception. "boom")]
+        (is (thrown? Exception (a/with-circuit-breaker cb (throw boom))))
+        (is (= :open (a/circuit-state cb)))
+
+        (reset! clock 500)
+        (is (a/circuit-open? (try (a/with-circuit-breaker cb :nope) (catch Exception e e)))
+            "still short-circuits before the reset timeout elapses")
+        (is (= :open (a/circuit-state cb)))
+
+        (reset! clock 1000)
+        (is (= :ok (a/with-circuit-breaker cb :ok)) "admits a probe once the timeout elapses")
+        (is (= :closed (a/circuit-state cb)) "a successful probe closes the breaker")))))
+
+(deftest test-circuit-breaker-half-open-failure-reopens
+  (let [clock (atom 0)]
+    (with-redefs [a/current-time-ms (fn [] @clock)]
+      (let [cb   (a/circuit-breaker (a/consecutive-failures 1) {::a/reset-timeout 1000})
+            boom (Exception. "boom")]
+        (is (thrown? Exception (a/with-circuit-breaker cb (throw boom))))
+
+        (reset! clock 1000)
+        (is (thrown? Exception (a/with-circuit-breaker cb (throw boom)))
+            "the probe runs but fails")
+        (is (= :open (a/circuit-state cb)) "a failed probe re-opens the breaker")
+
+        (reset! clock 1500)
+        (is (a/circuit-open? (try (a/with-circuit-breaker cb :nope) (catch Exception e e)))
+            "opened-at was restamped, so the timeout window restarts")
+
+        (reset! clock 2000)
+        (is (= :ok (a/with-circuit-breaker cb :ok)))
+        (is (= :closed (a/circuit-state cb)))))))
+
+(deftest test-circuit-breaker-half-open-single-probe
+  (let [clock  (atom 0)
+        allow! #'again.core/allow!]
+    (with-redefs [a/current-time-ms (fn [] @clock)]
+      (let [cb   (a/circuit-breaker (a/consecutive-failures 1) {::a/reset-timeout 1000})
+            boom (Exception. "boom")]
+        (is (thrown? Exception (a/with-circuit-breaker cb (throw boom))))
+        (reset! clock 1000)
+        (is (= true (::a/permitted? (allow! cb))) "first caller is admitted as the probe")
+        (is (= :half-open (a/circuit-state cb)))
+        (is (= false (::a/permitted? (allow! cb)))
+            "a second caller is denied while the probe is in flight")))))

--- a/test/again/core_test.clj
+++ b/test/again/core_test.clj
@@ -684,3 +684,34 @@
         (a/with-circuit-breaker cb (throw (InterruptedException.)))
         (catch InterruptedException _
           (is (.isInterrupted (Thread/currentThread))))))))
+
+(deftest test-circuit-breaker-events
+  (let [clock (atom 0)]
+    (with-redefs [a/current-time-ms (fn [] @clock)]
+      (let [events  (atom [])
+            cb      (a/circuit-breaker (a/consecutive-failures 1)
+                                       {::a/reset-timeout 1000
+                                        ::a/on-event      #(swap! events conj %)})
+            boom    (Exception. "boom")]
+        (a/with-circuit-breaker cb :ok)
+        (is (thrown? Exception (a/with-circuit-breaker cb (throw boom))))
+        (is (a/circuit-open? (try (a/with-circuit-breaker cb :nope) (catch Exception e e))))
+
+        (let [evs @events]
+          (is (= [:success :failure :state-change :short-circuit]
+                 (map ::a/event evs))
+              "fires success, then failure + the resulting state-change, then short-circuit")
+          (let [sc (first (filter #(= :state-change (::a/event %)) evs))]
+            (is (= :closed (::a/from sc)))
+            (is (= :open (::a/to sc))))
+          (let [f (first (filter #(= :failure (::a/event %)) evs))]
+            (is (= boom (::a/exception f)) "the failure event carries the exception")))))))
+
+(deftest test-circuit-breaker-events-user-context
+  (let [events (atom [])
+        ctx    {:name "svc"}
+        cb     (a/circuit-breaker (a/consecutive-failures 3)
+                                  {::a/on-event     #(swap! events conj %)
+                                   ::a/user-context ctx})]
+    (a/with-circuit-breaker cb :ok)
+    (is (= ctx (::a/user-context (first @events))) "user-context is attached to events")))

--- a/test/again/core_test.clj
+++ b/test/again/core_test.clj
@@ -669,3 +669,18 @@
         (is (= :half-open (a/circuit-state cb)))
         (is (= false (::a/permitted? (allow! cb)))
             "a second caller is denied while the probe is in flight")))))
+
+(deftest test-circuit-breaker-interrupt-not-recorded
+  (testing "InterruptedException does not count as a failure"
+    (let [cb (a/circuit-breaker (a/consecutive-failures 1))]
+      (try
+        (a/with-circuit-breaker cb (throw (InterruptedException.)))
+        (catch InterruptedException _))
+      (is (= :closed (a/circuit-state cb)) "an interrupt did not trip the breaker")))
+
+  (testing "the interrupt flag is restored before the exception propagates"
+    (let [cb (a/circuit-breaker (a/consecutive-failures 1))]
+      (try
+        (a/with-circuit-breaker cb (throw (InterruptedException.)))
+        (catch InterruptedException _
+          (is (.isInterrupted (Thread/currentThread))))))))

--- a/test/again/core_test.clj
+++ b/test/again/core_test.clj
@@ -715,3 +715,23 @@
                                    ::a/user-context ctx})]
     (a/with-circuit-breaker cb :ok)
     (is (= ctx (::a/user-context (first @events))) "user-context is attached to events")))
+
+(deftest test-circuit-breaker-with-retries-integration
+  (with-redefs [a/sleep (constantly nil)]
+    (testing "breaker-innermost counts each attempt; a ::fail callback stops retrying once open"
+      (let [cb           (a/circuit-breaker (a/consecutive-failures 3))
+            boom         (Exception. "boom")
+            attempts     (atom 0)
+            stop-on-open (fn [{e ::a/exception}]
+                           (when (and e (a/circuit-open? e)) ::a/fail))]
+        (try
+          (with-retries
+            {::a/strategy (repeat 10 1)
+             ::a/callback stop-on-open}
+            (a/with-circuit-breaker cb
+              (swap! attempts inc)
+              (throw boom)))
+          (catch Exception _))
+        (is (= :open (a/circuit-state cb)) "the breaker opened during the retries")
+        (is (= 3 @attempts)
+            "the body ran 3 times (each attempt counted); attempt 4 short-circuited and the callback stopped the loop")))))

--- a/test/again/core_test.clj
+++ b/test/again/core_test.clj
@@ -557,3 +557,25 @@
   (testing "rejects a non-positive threshold"
     (is (thrown? AssertionError (a/consecutive-failures 0)))
     (is (thrown? AssertionError (a/consecutive-failures -1)))))
+
+(deftest test-circuit-breaker-constructor
+  (testing "a new breaker starts closed"
+    (is (= :closed (a/circuit-state (a/circuit-breaker (a/consecutive-failures 3))))))
+
+  (testing "reset-timeout defaults to 60000 ms"
+    (is (= 60000 (::a/reset-timeout (a/circuit-breaker (a/consecutive-failures 3))))))
+
+  (testing "reset-timeout can be overridden"
+    (is (= 5000 (::a/reset-timeout
+                 (a/circuit-breaker (a/consecutive-failures 3) {::a/reset-timeout 5000})))))
+
+  (testing "on-event defaults to a function"
+    (is (fn? (::a/on-event (a/circuit-breaker (a/consecutive-failures 3))))))
+
+  (testing "user-context is absent unless supplied, and present when supplied"
+    (is (not (contains? (a/circuit-breaker (a/consecutive-failures 3)) ::a/user-context)))
+    (is (= :ctx (::a/user-context
+                 (a/circuit-breaker (a/consecutive-failures 3) {::a/user-context :ctx})))))
+
+  (testing "rejects a value that is not a BreakerPolicy"
+    (is (thrown? AssertionError (a/circuit-breaker :not-a-policy)))))

--- a/test/again/core_test.clj
+++ b/test/again/core_test.clj
@@ -517,3 +517,43 @@
          (with-retries (a/max-wall-clock-duration timeout (take n (repeat 0))) (f))
          (catch Exception _)))
      (= @attempts 1))))
+
+(deftest test-consecutive-failures-policy
+  (testing "does not trip before reaching the threshold of consecutive failures"
+    (let [p0 (a/consecutive-failures 3)
+          p1 (a/observe p0 :failure 0)
+          p2 (a/observe p1 :failure 0)]
+      (is (not (a/tripped? p0 0)))
+      (is (not (a/tripped? p1 0)))
+      (is (not (a/tripped? p2 0)))))
+
+  (testing "trips on the threshold-th consecutive failure"
+    (let [p (-> (a/consecutive-failures 3)
+                (a/observe :failure 0)
+                (a/observe :failure 0)
+                (a/observe :failure 0))]
+      (is (a/tripped? p 0))))
+
+  (testing "a success resets the failure count"
+    (let [p (-> (a/consecutive-failures 2)
+                (a/observe :failure 0)
+                (a/observe :success 0)
+                (a/observe :failure 0))]
+      (is (not (a/tripped? p 0)))))
+
+  (testing "reset clears accumulated failures and returns a working policy"
+    (let [p (-> (a/consecutive-failures 2)
+                (a/observe :failure 0)
+                (a/observe :failure 0))]
+      (is (a/tripped? p 0))
+      (let [p' (a/reset p)]
+        (is (not (a/tripped? p' 0)))
+        (is (a/tripped? (-> p'
+                            (a/observe :failure 0)
+                            (a/observe :failure 0))
+                        0)
+            "failures accumulate again after reset"))))
+
+  (testing "rejects a non-positive threshold"
+    (is (thrown? AssertionError (a/consecutive-failures 0)))
+    (is (thrown? AssertionError (a/consecutive-failures -1)))))

--- a/test/again/core_test.clj
+++ b/test/again/core_test.clj
@@ -579,3 +579,43 @@
 
   (testing "rejects a value that is not a BreakerPolicy"
     (is (thrown? AssertionError (a/circuit-breaker :not-a-policy)))))
+
+(deftest test-circuit-breaker-closed
+  (testing "a successful call returns its value and stays closed"
+    (let [cb (a/circuit-breaker (a/consecutive-failures 3))]
+      (is (= :ok (a/with-circuit-breaker cb :ok)))
+      (is (= :closed (a/circuit-state cb)))))
+
+  (testing "a failing call rethrows and stays closed below the threshold"
+    (let [cb   (a/circuit-breaker (a/consecutive-failures 3))
+          boom (Exception. "boom")]
+      (is (thrown? Exception (a/with-circuit-breaker cb (throw boom))))
+      (is (= :closed (a/circuit-state cb))))))
+
+(deftest test-circuit-breaker-trips-open
+  (let [cb   (a/circuit-breaker (a/consecutive-failures 2))
+        boom (Exception. "boom")
+        fail #(a/with-circuit-breaker cb (throw boom))]
+    (is (thrown? Exception (fail)))
+    (is (= :closed (a/circuit-state cb)) "one failure does not trip a threshold-2 breaker")
+    (is (thrown? Exception (fail)))
+    (is (= :open (a/circuit-state cb)) "the second consecutive failure trips it open")))
+
+(deftest test-circuit-breaker-success-resets-count
+  (let [cb   (a/circuit-breaker (a/consecutive-failures 2))
+        boom (Exception. "boom")]
+    (is (thrown? Exception (a/with-circuit-breaker cb (throw boom))))
+    (is (= :ok (a/with-circuit-breaker cb :ok)))
+    (is (thrown? Exception (a/with-circuit-breaker cb (throw boom))))
+    (is (= :closed (a/circuit-state cb)) "the success reset the count, so one failure does not trip")))
+
+(deftest test-circuit-breaker-open-short-circuits
+  (let [cb    (a/circuit-breaker (a/consecutive-failures 1))
+        boom  (Exception. "boom")
+        calls (atom 0)]
+    (is (thrown? Exception (a/with-circuit-breaker cb (throw boom))))
+    (is (= :open (a/circuit-state cb)))
+    (let [e (try (a/with-circuit-breaker cb (swap! calls inc) :never)
+                 (catch Exception ex ex))]
+      (is (a/circuit-open? e) "an open breaker throws a circuit-open exception")
+      (is (= 0 @calls) "the wrapped body is not executed while open"))))

--- a/test/again/core_test.clj
+++ b/test/again/core_test.clj
@@ -578,7 +578,11 @@
                  (a/circuit-breaker (a/consecutive-failures 3) {::a/user-context :ctx})))))
 
   (testing "rejects a value that is not a BreakerPolicy"
-    (is (thrown? AssertionError (a/circuit-breaker :not-a-policy)))))
+    (is (thrown? AssertionError (a/circuit-breaker :not-a-policy))))
+
+  (testing "rejects a negative reset-timeout"
+    (is (thrown? AssertionError
+                 (a/circuit-breaker (a/consecutive-failures 3) {::a/reset-timeout -1})))))
 
 (deftest test-circuit-breaker-closed
   (testing "a successful call returns its value and stays closed"


### PR DESCRIPTION
## Summary
- Adds a circuit breaker to `again.core` that complements `with-retries`: the `circuit-breaker` constructor + `with-circuit-breaker` macro, with closed/open/half-open states, a configurable failure threshold, and `::reset-timeout`.
- Trip logic sits behind a `BreakerPolicy` protocol — ships the `consecutive-failures` policy; rolling-count / time-window policies are future implementations of the same seam.
- Unified `::on-event` observability hook (`:success`, `:failure`, `:short-circuit`, `:state-change`); `circuit-open?` predicate and `circuit-state` introspection; an `::circuit-open` `ex-info` signals short-circuits.
- Thread-safe via a `compare-and-set!` loop (Clojure 1.8-compatible — no `swap-vals!`); single-probe half-open; `InterruptedException` is rethrown with the interrupt flag restored and is not recorded.
- Composes with `with-retries` by nesting (breaker innermost), so the breaker counts every attempt; a `::fail`-returning retry callback can stop early once the breaker opens. README + CHANGELOG updated.

Design spec: `docs/superpowers/specs/2026-06-11-circuit-breaker-design.md`

## Test Plan
- [ ] `clojure -X:test` — 40 tests / 146 assertions, 0 failures, 0 errors
- [ ] `clojure -M:fmt/check` — all source files formatted correctly
- Coverage: closed / trip-open / short-circuit; half-open probe → close, fail → reopen, single-probe invariant; `InterruptedException` not recorded + flag restored; `::on-event` sequence incl. exactly-once `:state-change`; `with-retries` composition. Deterministic — clock controlled via `with-redefs` on `current-time-ms`, no real sleeping.