### PR TITLE
ag-tmw: check for reflection warnings in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,8 @@ jobs:
       - name: Check formatting
         run: clojure -M:fmt/check
 
+      - name: Check for reflection warnings
+        run: clojure -M:check-reflection
+
       - name: Run tests
         run: clojure -X:test

--- a/deps.edn
+++ b/deps.edn
@@ -16,6 +16,13 @@
                 io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
    :exec-fn cognitect.test-runner.api/test}
 
+  ;; Compile the library and test namespaces with reflection warnings enabled and
+  ;; fail (exit 1) if any are emitted, so accidental runtime reflection is caught.
+  :check-reflection
+  {:extra-paths ["test"]
+   :extra-deps {org.clojure/test.check {:mvn/version "1.1.3"}}
+   :main-opts ["-e" "(let [w (java.io.StringWriter.)] (binding [*warn-on-reflection* true *err* w] (require 'again.core 'again.core-test :reload)) (let [s (str w)] (print s) (flush) (if (re-find #\"Reflection warning, again/\" s) (do (binding [*out* *err*] (println \"Reflection warnings found.\")) (System/exit 1)) (println \"No reflection warnings.\"))))"]}
+
   :fmt/check
   {:deps {cljfmt/cljfmt {:mvn/version "0.9.2"}}
    :main-opts ["-m" "cljfmt.main" "check" "src" "test" "build.clj" "deps.edn"]}


### PR DESCRIPTION
## Summary
- Adds a `:check-reflection` deps.edn alias that loads `again.core` with `*warn-on-reflection*` enabled, captures the compiler output, prints any warnings, and **exits non-zero** if a reflection warning is emitted.
- Wires it into CI (`.github/workflows/ci.yml`) as a step between the formatting check and the tests.
- Keeps the published library reflection-clean so accidental runtime reflection is caught in PRs rather than shipped.

## Test Plan
- [ ] `clojure -M:check-reflection` → `No reflection warnings.`, exit 0
- [ ] Verified the gate fails: adding a reflective form (`(.length x)` on an untyped arg) prints `Reflection warning, …` and exits 1; reverting returns it to clean/exit 0
- [ ] `clojure -M:fmt/check` clean; `clojure -X:test` green

Scope: targets reflection warnings on the library source (`again.core`). The test namespace's pre-existing `case` performance warnings are a different class and out of scope.