### PR TITLE
ag-3mc: silence case performance warnings in core-test

### DIFF
--- a/test/again/core_test.clj
+++ b/test/again/core_test.clj
@@ -407,7 +407,7 @@
     (testing "deadline exceeded after first failure stops retrying"
       (let [calls    (atom 0)
             {:keys [f attempts]} (new-failing-fn)]
-        (with-redefs [a/current-time-ms #(case (swap! calls inc) 1 0 11000)]
+        (with-redefs [a/current-time-ms #(case (long (swap! calls inc)) 1 0 11000)]
           (is (thrown? Exception
                        (with-retries (a/max-wall-clock-duration 10000 [100 100 100]) (f)))))
         (is (= @attempts 1) "only 1 attempt before wall-clock timeout fires")))
@@ -444,7 +444,7 @@
       (let [calls    (atom 0)
             {:keys [f]} (new-failing-fn)
             {:keys [args callback]} (new-callback-fn)]
-        (with-redefs [a/current-time-ms #(case (swap! calls inc) 1 0 11000)]
+        (with-redefs [a/current-time-ms #(case (long (swap! calls inc)) 1 0 11000)]
           (is (thrown? Exception
                        (with-retries (merge (a/max-wall-clock-duration 10000 [100 100])
                                             {::a/callback callback})


### PR DESCRIPTION
## Summary
The `max-wall-clock-duration` tests used `(case (swap! calls inc) 1 0 11000)`. `swap!` returns a boxed `Long`, so `case`'s integer fast-path can't apply and the compiler emits a `case has int tests, but tested expression is not primitive` performance warning (surfaced when compiling with `*warn-on-reflection*` enabled).

Coerced the tested expression to a primitive long — `(case (long (swap! calls inc)) 1 0 11000)` — at both call sites. Identical behaviour (first call → `0`, subsequent → `11000`), no warning.

Test-only change; no production code touched.

## Test Plan
- [ ] Suite compiled with `*warn-on-reflection*` enabled emits **no** reflection or performance warnings
- [ ] `clojure -X:test` green (27 tests / 86 assertions)
- [ ] `clojure -M:fmt/check` clean