### PR TITLE
ag-ehd: prepare 2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-06-13
+
 ### Added
 - `max-wall-clock-duration` manipulator: stops retrying once wall-clock elapsed
   time since the first attempt exceeds a given timeout. Unlike `max-duration`,
@@ -18,8 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   notifications (`:success`, `:failure`, `:short-circuit`, `:state-change`), and
   compose with `with-retries` by nesting (breaker innermost). `BreakerPolicy` is an
   extension seam for alternative trip policies (e.g. a rolling window).
-
-### Added
 - Callback `::status` gains a new `:interrupted` value when retrying is stopped
   by an `InterruptedException`, distinguishing it from `:failure` (retries
   exhausted). **Note:** callers that dispatch exhaustively on `::status` without
@@ -37,5 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial stable release.
 
-[Unreleased]: https://github.com/liwp/again/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/liwp/again/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/liwp/again/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/liwp/again/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -2,21 +2,36 @@
 
 [![CI](https://github.com/liwp/again/actions/workflows/ci.yml/badge.svg)](https://github.com/liwp/again/actions/workflows/ci.yml)
 
-A Clojure library for retrying an operation based on a retry strategy.
+A Clojure library for making operations resilient: **retrying** transient failures
+(`with-retries`) and **short-circuiting** persistently-failing dependencies
+(`with-circuit-breaker`).
+
+> **New in 2.0:** circuit breakers join retries as a first-class tool —
+> see [Circuit breakers](#circuit-breakers).
 
 ## Clojars
 
 ```clj
-[listora/again "1.0.0"]
+[listora/again "2.0.0"]
 ```
 
 With `deps.edn`:
 
 ```clj
-listora/again {:mvn/version "1.0.0"}
+listora/again {:mvn/version "2.0.0"}
 ```
 
 Requires Clojure 1.8 or later.
+
+## Upgrading to 2.0
+
+2.0 adds circuit breakers (see [Circuit breakers](#circuit-breakers)) alongside the
+existing retry API — existing `with-retries` code keeps working. The one breaking
+change is in the retry callback: `:again.core/status` can now also be `:interrupted`
+(when an `InterruptedException` stops retrying), in addition to `:success`, `:retry`,
+and `:failure`. If your callback dispatches exhaustively on the status without a
+`:default` case (e.g. a `defmulti` or `case` over `:again.core/status`), add an
+`:interrupted` branch.
 
 ## Development
 
@@ -68,6 +83,47 @@ Require the library:
 ```clj
 (require '[again.core :as again])
 ```
+
+*Again* provides two composable resilience tools:
+
+- **[Retries](#retries)** — retry an operation while it keeps throwing, following a
+  delay strategy (`with-retries`). For *transient* failures that are likely to pass
+  on a retry.
+- **[Circuit breakers](#circuit-breakers)** — stop calling a dependency that has been
+  failing consistently and fail fast until it recovers (`with-circuit-breaker`). For
+  *persistent* failures.
+
+The two are independent and **compose by nesting** — and the nesting order matters,
+because it decides what the breaker counts as a single failure:
+
+- **Breaker innermost** (retries on the outside): the breaker sees *every individual
+  attempt*, so a burst of retries against a sick dependency trips it quickly. This is
+  the recommended default.
+- **Breaker outermost** (retries on the inside): the breaker sees *one outcome per
+  fully-exhausted retry block*, so it counts whole logical operations, not attempts.
+
+A typical setup is breaker-innermost, paired with a retry callback that returns
+`::again/fail` on a circuit-open exception, so the retry loop stops the moment the
+breaker opens instead of sleeping through its remaining delays:
+
+```clj
+(def breaker
+  (again/circuit-breaker (again/consecutive-failures 5) {::again/reset-timeout 30000}))
+
+(again/with-retries
+  {::again/strategy (again/max-retries 10 (again/constant-strategy 100))
+   ;; once the breaker is open, stop retrying instead of waiting out the delays
+   ::again/callback (fn [{e ::again/exception}]
+                      (when (and e (again/circuit-open? e)) ::again/fail))}
+  (again/with-circuit-breaker breaker   ; ← innermost: the breaker counts every attempt
+    (call-some-service)))
+```
+
+Swap the two `with-…` forms and the breaker instead counts one failure per
+exhausted retry block. See [Retries](#retries) and [Circuit breakers](#circuit-breakers)
+for each tool on its own.
+
+## Retries
 
 *Again* provides a very simple (too simple?) API for retrying an operation:
 given a retry strategy and an operation, the operation will be retried according
@@ -252,7 +308,7 @@ first retry immediately:
   (cons 0 exponential-backoff-strategy))
 ```
 
-### Circuit breaker
+## Circuit breakers
 
 A circuit breaker short-circuits calls to a dependency that has been failing
 consistently, giving it time to recover and failing fast in the meantime. Construct
@@ -274,22 +330,50 @@ one breaker and share it across callers:
   (call-some-service))
 ```
 
-While the breaker is open, `with-circuit-breaker` throws instead of running the
-body; `(again/circuit-open? e)` recognises that exception, and
+Any exception the body throws counts as a failure, except `InterruptedException` —
+that is rethrown (with the interrupt flag restored) and is **not** counted. Once the
+breaker has been open for `::reset-timeout` milliseconds (default `60000`, also
+available as `again/default-reset-timeout`), it admits a single *half-open* probe: if
+the probe succeeds the breaker closes, if it fails the breaker re-opens for another
+timeout. While the breaker is open — or while a half-open probe is in flight —
+`with-circuit-breaker` short-circuits, throwing instead of running the body.
+`(again/circuit-open? e)` recognises that exception, and
 `(again/circuit-state breaker)` returns `:closed`, `:open`, or `:half-open`.
 
-Use retries and the breaker together by nesting, breaker innermost, so the breaker
-counts every attempt. A retry callback can stop early once the breaker opens:
+**Monitoring.** The `:again.core/on-event` callback (used above) is the observability
+hook. It fires after each notable event with a map whose `:again.core/event` is
+`:success`, `:failure`, `:short-circuit`, or `:state-change`; a `:state-change` also
+carries `:again.core/from`/`:again.core/to`, a `:failure` carries the
+`:again.core/exception`, and any configured `:again.core/user-context` rides along on
+every event. The breaker just emits these — feed them into your own logging or metrics
+(e.g. counting `:short-circuit` events shows how much load the breaker is shedding).
 
-```clj
-(again/with-retries
-  {:again.core/strategy (again/max-retries 10 (again/constant-strategy 100))
-   :again.core/callback (fn [{e :again.core/exception}]
-                          (when (and e (again/circuit-open? e))
-                            :again.core/fail))}
-  (again/with-circuit-breaker breaker
-    (call-some-service)))
-```
+**Custom trip behaviour.** `consecutive-failures` is the built-in policy, but *when a
+closed breaker trips* is pluggable: implement the `BreakerPolicy` protocol over an
+immutable value and pass it to `circuit-breaker` in place of `consecutive-failures`.
+Its three methods are:
+
+- `(observe [policy outcome now])` — return an updated policy for a `:success` or
+  `:failure` outcome
+- `(tripped? [policy now])` — whether the breaker should open
+- `(reset [policy])` — clear accumulated state when the breaker re-closes
+
+That's enough to plug in, say, a rolling-window or failure-rate policy. The
+open/half-open/closed state machine (including the single half-open probe) is
+unchanged — the policy only decides when a *closed* breaker trips.
+
+**API.**
+
+* `circuit-breaker` — construct a breaker from a `BreakerPolicy` and an options map
+  (`::reset-timeout`, `::on-event`, `::user-context`)
+* `with-circuit-breaker` — run a body through a breaker; short-circuits when open
+* `consecutive-failures` — the built-in `BreakerPolicy` (trip after N consecutive failures)
+* `circuit-open?` — whether an exception is the breaker's short-circuit signal
+* `circuit-state` — a breaker's current state: `:closed`, `:open`, or `:half-open`
+* `BreakerPolicy` — protocol for custom trip behaviour (`observe`/`tripped?`/`reset`)
+
+To combine a breaker with retries, see [Usage](#usage) — the nesting order matters,
+and breaker-innermost (so the breaker counts every attempt) is the usual choice.
 
 ## License
 

--- a/build.clj
+++ b/build.clj
@@ -3,7 +3,7 @@
             [deps-deploy.deps-deploy :as dd]))
 
 (def lib 'listora/again)
-(def version "1.1.0")
+(def version "2.0.0")
 (def class-dir "target/classes")
 (def jar-file (format "target/%s-%s.jar" (name lib) version))
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src"]
 
  ;; Library coordinate: listora/again
- ;; Current release: 1.0.0
+ ;; Current release: 2.0.0
  ;; Release target: Clojars
  :deps {org.clojure/clojure {:mvn/version "1.12.5"}}
 

--- a/src/again/core.clj
+++ b/src/again/core.clj
@@ -399,7 +399,9 @@
   "Run `body` through `breaker`. While the breaker is closed (or admitting a
   half-open probe) the body executes and its success or failure is recorded
   against the breaker. While the breaker is open the body is NOT executed; a
-  circuit-open exception (recognised by `circuit-open?`) is thrown instead.
+  circuit-open exception (recognised by `circuit-open?`) is thrown instead. Once
+  the breaker has been open for `::reset-timeout` ms it admits a single half-open
+  probe: a successful probe closes the breaker, a failed one re-opens it.
 
   Any thrown `Exception` counts as a failure: it is recorded against the breaker
   and then rethrown — except `InterruptedException`, which is rethrown with the


### PR DESCRIPTION
## Summary
Release prep for **2.0.0** — the circuit breaker plus all changes since 1.0.0.

- Bump version `1.1.0` → `2.0.0` in `build.clj`, and reconcile the `deps.edn` "Current release" comment (was `1.0.0`).
- Finalize `CHANGELOG.md`: `[Unreleased]` → `## [2.0.0] - 2026-06-13`, consolidate the two `### Added` blocks into one, and add the `2.0.0` compare links.

Major bump (2.0.0) is driven by the breaking callback change: `with-retries` `::status` now gains an `:interrupted` value, so callers dispatching exhaustively on `::status` without a `:default` arm must add an `:interrupted` case.

**After this merges:** tag `v2.0.0` on `main` and deploy to Clojars (`clojure -T:build jar` then `clojure -T:build deploy`).

## Test Plan
- [ ] `clojure -X:test` — 40 tests / 147 assertions, 0 failures
- [ ] `clojure -M:fmt/check` — clean
- [ ] `clojure -M:check-reflection` — clean