### PR TITLE
ag-ehd: fix release tooling (jar + deploy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Release coordinate: `listora/again`. Releases are published to Clojars.
    a deploy token, not your account password), then run:
    ```sh
    clojure -T:build jar
-   clojure -T:build deploy
+   clojure -X:deploy
    ```
 
 ---

--- a/build.clj
+++ b/build.clj
@@ -1,11 +1,12 @@
 (ns build
-  (:require [clojure.tools.build.api :as b]
-            [deps-deploy.deps-deploy :as dd]))
+  (:require [clojure.tools.build.api :as b]))
 
 (def lib 'listora/again)
 (def version "2.0.0")
 (def class-dir "target/classes")
-(def jar-file (format "target/%s-%s.jar" (name lib) version))
+;; Version-less jar name so the :deploy alias never needs a per-release edit;
+;; the published version comes from the embedded pom, not the filename.
+(def jar-file (format "target/%s.jar" (name lib)))
 
 (defn- basis []
   (b/create-basis {:project "deps.edn"}))
@@ -21,12 +22,7 @@
                             :developerConnection "scm:git:ssh://git@github.com/liwp/again.git"
                             :tag                 (str "v" version)}
                 :url       "https://github.com/liwp/again"})
-  (b/copy-src {:src-dirs  ["src"]
-               :class-dir class-dir})
+  (b/copy-dir {:src-dirs   ["src"]
+               :target-dir class-dir})
   (b/jar {:class-dir class-dir
           :jar-file  jar-file}))
-
-(defn deploy [_]
-  (dd/deploy {:installer :remote
-              :artifact  jar-file
-              :pom-file  (b/pom-path {:lib lib :class-dir class-dir})}))

--- a/deps.edn
+++ b/deps.edn
@@ -32,6 +32,14 @@
    :main-opts ["-m" "cljfmt.main" "fix" "src" "test" "build.clj" "deps.edn"]}
 
   :build
-  {:deps {org.clojure/tools.build {:mvn/version "0.9.2"}
-          slipset/deps-deploy     {:mvn/version "0.2.5"}}
-   :ns-default build}}}
+  {:deps {org.clojure/tools.build {:mvn/version "0.9.2"}}
+   :ns-default build}
+
+  ;; Deploy to Clojars: `clojure -X:deploy` (needs CLOJARS_USERNAME /
+  ;; CLOJARS_PASSWORD). Kept separate from :build so deps-deploy and tools.build
+  ;; never share a classpath — co-locating them clashes their tools.deps
+  ;; versions ("No such var: specs/valid-deps?").
+  :deploy
+  {:replace-deps {slipset/deps-deploy {:mvn/version "0.2.5"}}
+   :exec-fn deps-deploy.deps-deploy/deploy
+   :exec-args {:installer :remote :artifact "target/again.jar"}}}}


### PR DESCRIPTION
## Summary
`clojure -T:build jar` / `deploy` were broken by two latent bugs (the deps.edn build was migrated from Leiningen but `jar`/`deploy` was apparently never run):

1. **deps-deploy co-located with tools.build.** `slipset/deps-deploy` was a dep of the `:build` alias (required in `build.clj`), putting its `org.clojure/tools.deps.edn` on the same classpath as `tools.build`'s `org.clojure/tools.deps` → `No such var: specs/valid-deps?`. Fixed per the [Clojars wiki](https://github.com/clojars/clojars-web/wiki/Clojure-CLI-deps.edn): deploy is now its own isolated `:deploy` alias run with `clojure -X:deploy`, separate from `:build`.
2. **`b/copy-src`** in `build.clj` — not a real `tools.build` fn; replaced with `b/copy-dir` (`:target-dir`).

`build.clj` drops the deps-deploy require and the `deploy` fn. The jar is now named `target/again.jar` (version-less) so the `:deploy` alias never needs a per-release edit — the published version comes from the embedded pom. README's Releasing section now uses `clojure -X:deploy`.

## Test Plan
- [x] `clojure -T:build jar` → builds `target/again.jar` with embedded pom `<version>2.0.0</version>`
- [x] `:deploy` alias resolves cleanly, no tools.deps clash (full deploy needs Clojars creds)
- [x] `clojure -X:test` green (40 tests / 147 assertions); `clojure -M:fmt/check` clean