### PR TITLE
ag-ehd: make Clojars deploy work (pom-file, license, tools.build bump)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -42,4 +42,6 @@
   :deploy
   {:replace-deps {slipset/deps-deploy {:mvn/version "0.2.5"}}
    :exec-fn deps-deploy.deps-deploy/deploy
-   :exec-args {:installer :remote :artifact "target/again.jar"}}}}
+   :exec-args {:installer :remote
+               :artifact "target/again.jar"
+               :pom-file "target/classes/META-INF/maven/listora/again/pom.xml"}}}}


### PR DESCRIPTION
## Summary
Three fixes so `clojure -X:deploy` actually publishes to Clojars (the deps.edn build was never exercised end-to-end):

1. **`:pom-file`** — deps-deploy defaulted to `./pom.xml` (which `tools.build` doesn't create) → `pom.xml (No such file or directory)`. Point the `:deploy` alias at the generated pom under `target/classes/...`.
2. **License in the pom** — Clojars rejected the upload (403: *"the POM file does not include a license"*). Add the EPL 1.0 license via `b/write-pom`'s `:pom-data`.
3. **Bump `tools.build` 0.9.2 → 0.10.14** — `:pom-data` was silently ignored on 0.9.2 (added in 0.9.4); 0.9.2 was also the last Maven release, so this moves to `io.github.clojure/tools.build`. Safe now that deps-deploy lives in its own `:deploy` alias (no shared classpath).

## Test Plan
- [x] `clojure -T:build jar` → `target/again.jar`, pom has `<version>2.0.0</version>` and `<licenses>` (EPL 1.0)
- [x] `clojure -X:deploy` authenticated and uploaded to Clojars; previously failed at the license check (403), now the pom includes it
- [x] `clojure -M:fmt/check` clean